### PR TITLE
Fix the lack of handling the case of an error

### DIFF
--- a/src/cent.client.ts
+++ b/src/cent.client.ts
@@ -21,7 +21,6 @@ export class CentClient {
 		return (params?: CommandParams<M>): Promise<CommandResponse<M>> =>
 			this.post(this.centOptions.url, JSON.stringify({ method, params }))
 				.then(res => res.json() as any)
-				.then(res => res?.result)
 				.catch(err => {
 					throw new CentException(err);
 				});


### PR DESCRIPTION
There's a case when some commands can return error object instead of result. You should keep in touch with a documentation and provide a control to developers to handle these cases.
This would be a breaking change but it needs to be done.