### PR TITLE
feat: rename `token` to `apiKey` in the `CentOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const {CentClient} = require('cent.js');
 // Initialize client instance.
 const client = new CentClient({
     url: 'http://localhost:8000/api',
-    token: 'XXX'
+    apiKey: 'XXX'
 });
 
 // Publish data into channel

--- a/src/cent.client.ts
+++ b/src/cent.client.ts
@@ -12,7 +12,7 @@ export class CentClient {
 			body: data,
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `apikey ${this.centOptions.token}`
+				'X-API-Key': this.centOptions.apiKey
 			}
 		});
 	}

--- a/src/interfaces/cent-options.interface.ts
+++ b/src/interfaces/cent-options.interface.ts
@@ -1,5 +1,5 @@
 export interface CentOptions {
 	url: string;
-	token?: string;
+	apiKey?: string;
 	timeout?: number;
 }

--- a/test/cent.spec.ts
+++ b/test/cent.spec.ts
@@ -1,9 +1,9 @@
-import { CentClient, CentMethods } from '../src';
+import { CentClient } from '../src';
 
 describe('Centrifugo API Client', () => {
 	const client = new CentClient({
 		url: process.env.CENTRIFUGO_HOST,
-		token: process.env.CENTRIFUGO_TOKEN
+		apiKey: process.env.CENTRIFUGO_API_KEY
 	});
 
 	it('should return info', async () => {


### PR DESCRIPTION
- Rename `token` to `apiKey` 
- Pass it in the header since it's the recommended way & [it's considered more secure](https://centrifugal.dev/docs/server/server_api#http-api-authorization)